### PR TITLE
replace tomcat with undertow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,10 @@ sourceSets {
 
 dependencies {
   compile('org.apache.maven:maven-artifact:3.5.4')
-  compile('org.springframework.boot:spring-boot-starter-webflux')
+  compile('org.springframework.boot:spring-boot-starter-webflux'){
+    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+  }
+  runtimeOnly 'org.springframework.boot:spring-boot-starter-undertow'
   compile('org.springframework.boot:spring-boot-starter-thymeleaf')
   compileOnly('com.google.code.findbugs:jsr305:3.0.2')
   compile('org.codehaus.janino:janino:3.0.8')


### PR DESCRIPTION
## Tomcat

2018-08-11 21:39:16.513  INFO 77773 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.416 seconds (JVM running for 5.098)
2018-08-11 21:31:20.831  INFO 77373 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.803 seconds (JVM running for 5.561)
2018-08-11 21:38:35.044  INFO 77739 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 4.034 seconds (JVM running for 6.82)

## Undertow

2018-08-11 21:37:15.768  INFO 77568 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.551 seconds (JVM running for 5.062)
2018-08-11 21:37:02.017  INFO 77542 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.681 seconds (JVM running for 5.194)
2018-08-11 21:36:36.577  INFO 77517 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.749 seconds (JVM running for 5.251)

## Jetty

2018-08-11 21:44:14.247  INFO 78032 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.51 seconds (JVM running for 5.231)
2018-08-11 21:42:20.239  INFO 77962 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.821 seconds (JVM running for 5.264)
2018-08-11 21:43:32.237  INFO 78000 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 3.703 seconds (JVM running for 5.743)