### PR TITLE
Move image build to docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,8 @@ jdk:
   - oraclejdk8
 sudo: required
 
-services:
-  - docker
-before_install:
-  - echo "$DOCKER_HUB_PASSWORD" | docker login -u kengotoda --password-stdin
 script:
   - ./gradlew
-before_deploy:
-  - docker build --tag kengotoda/javadocky .
 jobs:
   include:
     - stage: analysis
@@ -23,13 +17,6 @@ addons:
     organization: "kengotoda-github"
     token:
       secure: "EWPkBtY4AzvId1eRAweDxB6jvUJkdaHJe8FYVSa5p067c04yJ+s1MCQLFUKLC/UkuWxXyQFsTNsfINpgvJ0LJ6foYreSGSJNmC/bPXnSGywi++5Rq9Y4puFz+opqelxslAfvhPKkGTmats/BFPq0pOrMFnQULh4WuOzBMaQiESAIHRbPAjuO4chT0ykpJTojKYvRaMebTwyGCIna0K4bkEt8K1fekxs+a5zbz3FwCU5ZEOkQQHALpX3mphKeXPR5nWfU8A6iivIGzkHK1QuBp9/MLMQH5k1i4HI5n2KzMO1A1qdSyFC+Mz7C97o9G8MF+mjs1M/rjuv+D9mBk1Il8jhR6MWoK3gtYOxLM29OltyuDvbW1ptCH0GPPG9v+XAnV3TUjDGXdYnKpSLGlqq9DeIFTM4Uo6L9xptks+r00qiM9CA4f8p8x4KKLQBwBxUo6GfV8HAHKT4a/ReMiBwbyR0I59CVhoLbi1x4tpZenocg/yM3ykY+YleIO8kNtdHxSZ7ij21Cs+ZfO/TNkU8ksxzGKY1G/28yLqd4w22+Dz1T2JpK5JQ3Kol55sPmR2ML3zO2Uv7K8tYBaXJLg1RbykHEe7+cWJHniTFQW/YUAl5+XYt4ExQvRQb1ZsQN3SGRtOfqGaVv8Vy9RooK+SUd/yB599BRxqdZOhMHN+pHl5A="
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script: docker push kengotoda/javadocky
-  on:
-    branch: master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-sudo: required
 
 script:
   - ./gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # https://spring.io/guides/gs/spring-boot-docker/
 
 FROM openjdk:8-alpine
+ADD . /code/
+RUN cd /code && ./gradlew assemble
+
+FROM openjdk:8-jre-alpine
 RUN addgroup user && adduser -D -G user -h /home/user -s /bin/bash user && mkdir /home/user/.javadocky && chown -R user:user /home/user/.javadocky
 WORKDIR /home/user
 USER user
 VOLUME /home/user/.javadocky
-ADD build/libs/javadocky-*.jar /home/user/javadocky.jar
+COPY --from=0 /code/build/libs/javadocky-*.jar /home/user/javadocky.jar
 ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar /home/user/javadocky.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # https://spring.io/guides/gs/spring-boot-docker/
 
 FROM openjdk:8-alpine
-ADD . /code/
-RUN cd /code && ./gradlew assemble
+ADD . /javadocky/
+RUN cd /javadocky && ./gradlew assemble
 
 FROM openjdk:8-jre-alpine
 RUN addgroup user && adduser -D -G user -h /home/user -s /bin/bash user && mkdir /home/user/.javadocky && chown -R user:user /home/user/.javadocky
 WORKDIR /home/user
 USER user
 VOLUME /home/user/.javadocky
-COPY --from=0 /code/build/libs/javadocky-*.jar /home/user/javadocky.jar
+COPY --from=0 /javadocky/build/libs/javadocky-*.jar /home/user/javadocky.jar
 ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar /home/user/javadocky.jar" ]


### PR DESCRIPTION
Docker Hub provides enough feature to build and deploy docker images, so Travis CI doesn't need to handle it.