### PR TITLE
introduce jlink to make minimal JRE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gradle
+build
+docker-compose.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM adoptopenjdk/openjdk11:alpine
 COPY . /javadocky/
 RUN cd /javadocky && ./gradlew assemble
 
-FROM amazoncorretto:11 as jlink
+FROM adoptopenjdk/openjdk11:alpine as jlink
 RUN jlink \
     --add-modules java.base,java.desktop,java.management,java.xml,java.naming,java.net.http,java.sql \
     --strip-debug \
@@ -14,11 +14,38 @@ RUN jlink \
     --no-man-pages \
     --output /jlink
 
-FROM amazonlinux:2
-RUN mkdir -p /javadocky/.javadocky
-WORKDIR /javadocky
+FROM alpine:3.9
 ENV JAVA_HOME=/opt/jre
 ENV PATH=${PATH}:${JAVA_HOME}/bin
+# copied from https://github.com/AdoptOpenJDK/openjdk-docker/blob/master/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+RUN apk add --no-cache --virtual .build-deps curl binutils \
+    && GLIBC_VER="2.29-r0" \
+    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.2.1%2B20180831-1-x86_64.pkg.tar.xz" \
+    && GCC_LIBS_SHA256=e4b39fb1f5957c5aab5c2ce0c46e03d30426f3b94b9992b009d417ff2d56af4d \
+    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.9-1-x86_64.pkg.tar.xz" \
+    && ZLIB_SHA256=bb0959c08c1735de27abf01440a6f8a17c5c51e61c3b4c707e988c906d3b7f67 \
+    && curl -Ls https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
+    && echo "${SGERRAND_RSA_SHA256}  /etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
+    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/${GLIBC_VER}.apk \
+    && apk add /tmp/${GLIBC_VER}.apk \
+    && curl -Ls ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
+    && echo "${GCC_LIBS_SHA256}  /tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && mkdir /tmp/gcc \
+    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
+    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
+    && curl -Ls ${ZLIB_URL} -o /tmp/libz.tar.xz \
+    && echo "${ZLIB_SHA256}  /tmp/libz.tar.xz" | sha256sum -c - \
+    && mkdir /tmp/libz \
+    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
+    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
+    && apk del --purge .build-deps \
+    && rm -rf /tmp/${GLIBC_VER}.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+
+RUN mkdir -p /javadocky/.javadocky
+WORKDIR /javadocky
 VOLUME /javadocky/.javadocky
 COPY --from=0 /javadocky/build/libs/javadocky-*.jar /javadocky/javadocky.jar
 COPY --from=1 /jlink $JAVA_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
 # https://spring.io/guides/gs/spring-boot-docker/
 
+# build the jar file to use
 FROM adoptopenjdk/openjdk11:alpine
-ADD . /javadocky/
+COPY . /javadocky/
 RUN cd /javadocky && ./gradlew assemble
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM adoptopenjdk/openjdk11:alpine as runtime
+RUN jlink \
+    --add-modules java.base,java.desktop,java.management,java.xml,java.naming,java.net.http,java.sql \
+    --strip-debug \
+    --compress 2 \
+    --no-header-files \
+    --no-man-pages \
+    --output /jlink && \
+    rm -rf ${JAVA_HOME} && \
+    mv -f /jlink ${JAVA_HOME}
 RUN addgroup user && adduser -D -G user -h /home/user -s /bin/bash user && mkdir /home/user/.javadocky && chown -R user:user /home/user/.javadocky
 WORKDIR /home/user
 USER user
 VOLUME /home/user/.javadocky
-COPY --from=0 /javadocky/build/libs/javadocky-*.jar /home/user/javadocky.jar
+COPY --from=0 --chown=user:user /javadocky/build/libs/javadocky-*.jar /home/user/javadocky.jar
 ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar /home/user/javadocky.jar" ]


### PR DESCRIPTION
### before
```sh
$ docker image inspect javadocky_app --format='{{.Size}}' | numfmt -z --to=iec-i --suffix=B --padding=6
156MiB
```

### on amazoncorretto (ec63e58)

```sh
$ docker image inspect javadocky_app --format='{{.Size}}' | numfmt -z --to=iec-i --suffix=B --padding=6
230MiB
```

### on adaptopenjdk (d396cbb)

```sh
$ docker image inspect javadocky_app --format='{{.Size}}' | numfmt -z --to=iec-i --suffix=B --padding=6
86MiB
```
