### PR TITLE
Remove agent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - remove-agent
 
 permissions:
   packages: write # to deploy to ghcr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - remove-agent
 
 permissions:
   packages: write # to deploy to ghcr

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN ./gradlew shadowJar --no-daemon
 
 FROM eclipse-temurin:17-alpine as JLINK
 RUN jlink \
-    --add-modules java.base,java.desktop,java.management,java.xml,java.naming,java.net.http,java.sql,java.instrument,jdk.unsupported,java.rmi \
+    --add-modules java.base,java.desktop,java.management,java.xml,java.naming,java.net.http,jdk.unsupported \
     --strip-java-debug-attributes \
     --compress 2 \
     --no-header-files \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ USER user
 VOLUME /app/.javadocky
 
 # https://cloud.google.com/run/docs/tips/java#optimization-compiler
-ENV JAVA_TOOL_OPTIONS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+# https://cloud.google.com/run/docs/tips/java#thread-stack
+ENV JAVA_TOOL_OPTIONS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xss256k"
 
 # https://cloud.google.com/run/docs/tips/java#lazy-init
 ENV SPRING_MAIN_LAZY_INITIALIZATIION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,6 @@ ENV JAVA_TOOL_OPTIONS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
 # https://cloud.google.com/run/docs/tips/java#lazy-init
 ENV SPRING_MAIN_LAZY_INITIALIZATIION=true
 
-# for New Relic
-ENV NEW_RELIC_APP_NAME="javadocky"
-ENV NEW_RELIC_LOG_FILE_NAME="STDOUT"
-RUN cd /home/user/.javadocky && \
-    wget https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip && \
-    unzip newrelic-java.zip && rm newrelic-java.zip
-
 COPY --from=JAR /javadocky/build/libs/javadocky-*.jar /app/javadocky.jar
 COPY --from=JLINK /jlink $JAVA_HOME
 # TODO: resolve `OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended`
@@ -44,4 +37,4 @@ RUN java -XX:DumpLoadedClassList=/home/user/classes.lst -jar /app/javadocky.jar 
     java -Xshare:dump -XX:SharedClassListFile=/home/user/classes.lst -XX:SharedArchiveFile=/home/user/appcds.jsa --class-path /app/javadocky.jar && \
     rm /home/user/classes.lst
 
-ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -Xshare:on -XX:SharedArchiveFile=/home/user/appcds.jsa -javaagent:/home/user/.javadocky/newrelic/newrelic.jar -jar /app/javadocky.jar" ]
+ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -Xshare:on -XX:SharedArchiveFile=/home/user/appcds.jsa -jar /app/javadocky.jar" ]

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
 
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.6.1")
-    implementation("de.undercouch:gradle-download-task:5.1.0")
     implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:2.0.2")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")

--- a/buildSrc/src/main/kotlin/conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions.gradle.kts
@@ -1,6 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
-import de.undercouch.gradle.tasks.download.Download
 import net.ltgt.gradle.errorprone.errorprone
 import org.sonarqube.gradle.SonarQubeTask
 
@@ -9,7 +8,6 @@ plugins {
     `jacoco`
     `kotlin`
     id("com.diffplug.spotless")
-    id("de.undercouch.download")
     id("net.ltgt.errorprone")
     id("org.sonarqube")
     id("com.github.johnrengelman.shadow")
@@ -23,21 +21,7 @@ val jacocoTestReport = tasks.jacocoTestReport {
     }
 }
 
-val downloadNewrelic by tasks.registering(Download::class) {
-    src("https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip")
-    dest(file("$buildDir"))
-}
-
-val unzipNewrelic by tasks.registering(Copy::class) {
-    dependsOn(downloadNewrelic)
-    from(zipTree(file("$buildDir/newrelic-java.zip")))
-    into("$buildDir")
-}
-
 tasks {
-    build {
-        dependsOn(unzipNewrelic)
-    }
     check {
         dependsOn(jacocoTestReport)
     }


### PR DESCRIPTION
the previous performance is 3.937 seconds (JVM running for 11.562) at https://github.com/KengoTODA/javadocky/pull/334#issuecomment-1139261948

### remove the NewRelic javaagent

> # on Codespaces
> 2022-05-27 23:23:02.064  INFO 1 --- [           main] j.s.javadocky.JavadockyApplication       : Started JavadockyApplication in 0.708 seconds (JVM running for 0.929)

> # on Cloud Run
> 2022-05-28 07:36:17.688 CST2022-05-27 23:36:17.688 INFO 1 --- [ main] j.s.javadocky.JavadockyApplication : Started JavadockyApplication in 1.695 seconds (JVM running for 2.768)
