### PR TITLE
Add dynamic authentication to WebClient based on user/pass

### DIFF
--- a/src/main/java/jp/skypencil/javadocky/JavadockyApplication.java
+++ b/src/main/java/jp/skypencil/javadocky/JavadockyApplication.java
@@ -64,10 +64,12 @@ public class JavadockyApplication {
 
   @Bean
   public JavadocDownloader javadocDownloader(
-      @Value("${javadocky.maven.repository}") String repoURL) {
+      @Value("${javadocky.maven.repository}") String repoURL, 
+      @Value("${javadocky.maven.repository.user}") String user, 
+      @Value("${javadocky.maven.repository.pass}")String pass) {
     Path home = Paths.get(System.getProperty(USER_HOME), JAVADOCKY_ROOT, JAVADOC_DIR);
     home.toFile().mkdirs();
     log.info("Making javadoc storage at {}", home.toFile().getAbsolutePath());
-    return new JavadocDownloader(home, repoURL);
+    return new JavadocDownloader(home, repoURL, user, pass);
   }
 }

--- a/src/main/java/jp/skypencil/javadocky/service/JavadocDownloader.java
+++ b/src/main/java/jp/skypencil/javadocky/service/JavadocDownloader.java
@@ -31,9 +31,16 @@ public class JavadocDownloader {
   private final Path root;
 
   @Autowired
-  public JavadocDownloader(@NonNull Path root, @NonNull String repoURL) {
+  public JavadocDownloader(@NonNull Path root, @NonNull String repoURL, String user, String pass) {
     this.root = Objects.requireNonNull(root);
-    this.webClient = WebClient.create(Objects.requireNonNull(repoURL));
+
+    WebClient.Builder builder  = WebClient.builder()
+                     .baseUrl(Objects.requireNonNull(repoURL));
+
+    if(user!= null && pass!=null && !user.isEmpty() && !pass.isEmpty())
+          builder.defaultHeaders(headers -> headers.setBasicAuth(user, pass));
+
+    this.webClient = builder.build();
   }
 
   Mono<Optional<File>> download(String groupId, String artifactId, String version) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 javadocky.maven.repository=https://repo.maven.apache.org/maven2/
+javadocky.maven.repository.user=
+javadocky.maven.repository.pass=


### PR DESCRIPTION
WebClient now conditionally adds Basic Auth header only if user and password are provided. Allows unauthenticated requests when credentials are empty.
