### PR TITLE
chore(deps): set Renovate minimum release age to 3 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "minimumReleaseAge": "3 days",
   "extends": ["config:best-practices"]
 }


### PR DESCRIPTION
Set the top-level `minimumReleaseAge` to `"3 days"` in `renovate.json` so dependency updates use a three-day release-age threshold.

Validation: parsed the updated JSON, verified all existing settings are unchanged, and confirmed the committed diff contains only the one-line addition.

[Renovate minimumReleaseAge documentation](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)